### PR TITLE
feat: add 'goto' command to navigate to branch, stack, or commit

### DIFF
--- a/src/app/goto.rs
+++ b/src/app/goto.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::{data, errors, git};
+
+pub fn goto(name: &str) -> Result<()> {
+
+    if !git::repo::is_repo()? {
+        return Err(errors::GitError::NotGitRepository.into());
+    }
+
+    let state = data::SolMetadata::load()?;
+
+    // Stack check
+    if state.has_stack(name) {
+        // We will get its root branch
+        let stack = state.get_stack(name)?;
+        git::branch::switch(&stack.head_branch.name, false)?;
+        println!("Switched to stack '{}'", name.blue());
+        return Ok(());
+    }
+
+    // We are here... so everything from this point on must be within the current stack
+    let current_stack = state.get_current_stack()?;
+
+    // Branch check
+    if state.has_branch(name) && current_stack.has_branch(name){
+        // We will switch to this branch
+        git::branch::switch(name, false)?;
+        println!("Switched to branch '{}'", name.blue());
+        return Ok(());
+    }
+
+    // Commit check -- Must be within this current branch
+    if git::commit::is_commit(name) {
+        // We will switch to this commit
+        git::branch::switch_to_commit(name)?;
+        println!("Switched to commit '{}'", name.blue());
+        return Ok(());
+    }
+
+    Ok(())
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,3 +3,4 @@ pub mod init;
 pub mod log;
 pub mod prev;
 pub mod next;
+pub mod goto;

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -21,4 +21,8 @@ pub enum Cmd {
     /// Navigate to the next branch in the stack
     #[clap(alias = "n")]
     Next(crate::cli::next::Next),
+
+    /// Navigate to a branch, stack, or commit
+    #[clap(alias = "g")]
+    Goto(crate::cli::goto::Goto),
 }

--- a/src/cli/goto.rs
+++ b/src/cli/goto.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use clap::Parser;
+
+use crate::app;
+
+#[derive(Parser, Debug)]
+pub struct Goto {
+    /// The name of the branch, stack, or commit to switch to
+    pub name: String,
+}
+
+impl Goto {
+    pub async fn run(&self) -> Result<()> {
+        app::goto::goto(&self.name)
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod init;
 pub mod log;
 pub mod prev;
 pub mod next;
+pub mod goto;
 
 pub trait Run {
     async fn run(&self) -> Result<()>;
@@ -21,6 +22,7 @@ impl Run for Cmd {
             Cmd::Prev(prev) => prev.run().await,
             Cmd::Log(log) => log.run().await,
             Cmd::Next(next) => next.run().await,
+            Cmd::Goto(goto) => goto.run().await,
         }
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -27,6 +27,7 @@ pub struct StackBranch {
     pub parent: Option<String>,   // Name of the parent branch, if any
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
+    pub depth: u8,
 }
 
 /// Status of a branch within the stack.

--- a/src/data/operations.rs
+++ b/src/data/operations.rs
@@ -72,6 +72,7 @@ impl StackBranch {
             parent: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            depth: 0,
         }
     }
 
@@ -130,5 +131,13 @@ impl SolMetadata {
             .find(|stack| stack.has_branch(&branch_name))
             .ok_or_else(|| anyhow!("No stack found for current branch."))?;
         Ok(stack)
+    }
+
+    /// Get stack by name
+    pub fn get_stack(&self, name: &str) -> Result<&Stack> {
+        self.stacks
+            .iter()
+            .find(|stack| stack.name == name)
+            .ok_or_else(|| anyhow!("Stack not found"))
     }
 }

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -95,3 +95,12 @@ mod tests {
         }
     }
 }
+
+/// Switches to the commit specified by the hash.
+pub fn switch_to_commit(commit_hash: &str) -> Result<()> {
+    Command::new("git")
+        .arg("checkout")
+        .arg(commit_hash)
+        .output()?;
+    Ok(())
+}

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -7,3 +7,17 @@ pub fn get_hash() -> Result<String> {
 
     Ok(String::from_utf8(output.stdout)?.trim().to_string())
 }
+
+/// is_commit checks if the given commit hash is valid.
+pub fn is_commit(commit_hash: &str) -> bool {
+    let output = Command::new("git")
+        .arg("cat-file")
+        .arg("-e")
+        .arg(commit_hash)
+        .output();
+
+    match output {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}


### PR DESCRIPTION
Added `goto` command that allows the user to traverse stacks, branches, and commits